### PR TITLE
fix: add docker support and remove MacOS from GHA

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -6,7 +6,7 @@ on:
       - .github/workflows/run-tests.yaml
       - tests/**
       - docker-here
-      - **/*.sh
+      - "**/*.sh"
   pull_request:
     types:
       - opened
@@ -15,30 +15,44 @@ on:
       - .github/workflows/run-tests.yaml
       - tests/**
       - docker-here
-      - **/*.sh
+      - "**/*.sh"
 
 permissions:
   contents: read
+
+defaults:
+  run:
+    working-directory: ./tests
 
 jobs:
   test:
     strategy:
       fail-fast: false
       matrix:
-        - macos-latest
-        - ubuntu-latest
+        include:
+          - runner_id: ubuntu-latest
 
-    runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner_id }}
+    name: Test ${{ matrix.runner_id }}
 
-    # Give a large enough value as MacOS runners can be slow.
-    timeout-minutes: 10
+    timeout-minutes: 5
 
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        with:
+          python-version: '3.13'
+
+      - name: Install Dependencies
+        run: |
+          pip install poetry
+          poetry install --with dev
+
+      # Note: we don't use 'make test' here due to the containers
+      #       using Linux, thus we cannot test the behavior of our
+      #       script against non-Linux operating systems.
       - name: Run Tests
-        working-directory: ./tests
-        run: make
+        run: poetry run pytest .
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 release:
 	mkdir -p dist/
 	tar -cf dist/docker-here.tar ./docker-here
-	sha256sum docker-here > dist/CHECKSUMS
+	sha256sum docker-here > dist/CHECKSUMS-SHA256.txt
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Quickly run container images anywhere in the current directory!
 
 </div>
 
+**Contents:**
+
+- [Usage](#usage)
+- [Installation](#installation)
+- [Demo](#demo)
+- [Full Usage](#full-usage)
+
 
 ## Usage
 
@@ -70,6 +77,7 @@ BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
 
 ```
 Usage: docker-here [OPTIONS...] [--] IMAGE [ARGS...]
+
 docker-here - Runs a given container image in a given directory (defaults to current
 directory)
 
@@ -101,11 +109,18 @@ OPTIONS
   --                    Indicates the end of the options for docker-here.
 
 POSITIONAL ARGUMENTS
+  IMAGE   The container image to run.
   ARGS    The arguments to pass to 'docker run'.
+
+ENVIRONMENT VARIABLES
+  DOCKER_EXE_PATH   The path to the 'docker' command executable (or similar
+                    such as podman).
+
+                    Default behavior: automatically detects the command to use.
 
 EXAMPLES
     docker-here alpine ls .
-    docker-here alpine sh -uxc 'ls -l "/home/iza/Development/.dotfiles-dev/home/Tools" ; cat /etc/os-release'
+    docker-here alpine sh -uxc 'ls -l "$PWD" ; cat /etc/os-release'
     docker-here alpine --src ~/Downloads -- ls -l .
     docker-here alpine --dest /foo -- ls -l /foo
     docker-here alpine:latest@sha256:d34db33f[...] -- ls -l /foo

--- a/docker-here
+++ b/docker-here
@@ -173,6 +173,11 @@ else
     docker=$(get_docker)
 fi
 
+# If we are running inside TTY, then add '-ti' to the 'docker run' arguments.
+if [[ -t 1 ]]; then
+    docker_run_args+=( -ti )
+fi
+
 # Use full path to avoid relative directories (may not play well
 # with some docker CLIs otherwise)
 src_path=$(readlink -f "$src_path")
@@ -183,7 +188,7 @@ if [[ -z "$dest_path" ]]; then
     dest_path="$src_path"
 fi
 
-"$docker" run --rm -it \
+"$docker" run --rm \
     "${docker_run_args[@]}" \
     -v "$src_path":"$dest_path" \
     --workdir "$dest_path" \

--- a/docker-here
+++ b/docker-here
@@ -7,6 +7,7 @@ usage() {
 
     # Note: convention used is max line length of 80 chars.
     echo $"Usage: $name [OPTIONS...] [--] IMAGE [ARGS...]
+
 $name - Runs a given container image in a given directory (defaults to current
 directory)
 
@@ -38,11 +39,18 @@ OPTIONS
   --                    Indicates the end of the options for $name.
 
 POSITIONAL ARGUMENTS
+  IMAGE   The container image to run.
   ARGS    The arguments to pass to 'docker run'.
+
+ENVIRONMENT VARIABLES
+  DOCKER_EXE_PATH   The path to the 'docker' command executable (or similar
+                    such as podman).
+
+                    Default behavior: automatically detects the command to use.
 
 EXAMPLES
     $name alpine ls .
-    $name alpine sh -uxc 'ls -l \"$PWD\" ; cat /etc/os-release'
+    $name alpine sh -uxc 'ls -l \"\$PWD\" ; cat /etc/os-release'
     $name alpine --src ~/Downloads -- ls -l .
     $name alpine --dest /foo -- ls -l /foo
     $name alpine:latest@sha256:d34db33f[...] -- ls -l /foo"
@@ -50,7 +58,7 @@ EXAMPLES
 
 
 get_docker() {
-    supported_commands=( docker, podman )
+    supported_commands=( docker podman )
 
     for cmd in "${supported_commands[@]}"; do
         if command -v "$cmd"; then
@@ -157,7 +165,13 @@ if [[ -z "$image" ]]; then
 fi
 
 # Retrieve a docker cli command (e.g., /usr/bin/docker, or /usr/bin/podman)
-docker=$(get_docker)
+if [[ -n "${DOCKER_EXE_PATH-}" ]]; then
+    # Use the user provided executable path
+    docker="$DOCKER_EXE_PATH"
+else
+    # Auto-detect 'docker' executable path
+    docker=$(get_docker)
+fi
 
 # Use full path to avoid relative directories (may not play well
 # with some docker CLIs otherwise)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,6 +19,6 @@ test:
 
 shell:
 	../docker-here $(docker_here_args) \
-		$(install_commands) \
+		'$(install_commands) \
 		&& bash -i'
 


### PR DESCRIPTION
Changes:
- Fixed a crash on systems that use `docker` instead of `podman` (was trying to run things like: `docker, run alpine ls` - where `,` is invalid)
- Removed MacOS tests from the tests GitHub Workflow. The MacOS runners does not ship docker-desktop, installing `podman` as a workaround is not currently possible due to crashes when running `podman machine start`.
- Fixed crash when running `make shell`
- docs: added missing documentation for the `IMAGE` positional argument

Features:
- Added possibility to pass a custom "`docker`" executable via environment variable (`DOCKER_EXE_PATH`).
    - Allow users to workaround any issues if their container backend isn't supported yet by `docker-here` (only `docker` and `podman` are currently supported out of the box)
    - Also allows to write wrappers around `docker run` commands (e.g., injecting/prepending arguments such as `docker run --os [...]`)