### PR TITLE
fix: volume permissions on rootless OCI runtimes

### DIFF
--- a/docker-here
+++ b/docker-here
@@ -190,7 +190,7 @@ fi
 
 "$docker" run --rm \
     "${docker_run_args[@]}" \
-    -v "$src_path":"$dest_path" \
+    -v "$src_path":"$dest_path":Z,U \
     --workdir "$dest_path" \
     "$image" \
     "$@"

--- a/docker-here
+++ b/docker-here
@@ -190,7 +190,7 @@ fi
 
 "$docker" run --rm \
     "${docker_run_args[@]}" \
-    -v "$src_path":"$dest_path":Z,U \
+    -v "$src_path":"$dest_path":Z \
     --workdir "$dest_path" \
     "$image" \
     "$@"


### PR DESCRIPTION
This fixes inability to write into mounted directories when the `Dockerfile` contains a `USER` statement in rootless container runtimes (such as podman)

This issue does not happen when the container uses the root users or when using an entrypoint that sets the UID and GID dynamically.