### PR TITLE
feat: forward unrecognized options to docker-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
 ## Full Usage
 
 ```
-Usage: docker-here [OPTIONS...] [--] IMAGE [ARGS...]
+Usage: docker-here [OPTIONS...] [DOCKER_OPTIONS...] [--] IMAGE [ARGS...]
 
 docker-here - Runs a given container image in a given directory (defaults to current
 directory)
@@ -94,19 +94,19 @@ OPTIONS
 
                           Default: $PWD
 
-  --privileged            Run the container as privileged (passes
-                          '--privileged' to 'docker run')
-
-  --entrypoint COMMAND  The entrypoint to pass to 'docker run'.
-
-  --pull       POLICY   The pull policy to pass to 'docker run'.
-                        Options: always, missing, never, newer
-                                 (default: 'missing')
-
-                        Note: the actual options may vary between docker
-                              backends (e.g., docker vs podman).
-
   --                    Indicates the end of the options for docker-here.
+
+DOCKER OPTIONS
+  Any options that unrecognized by 'docker-here' will be forwarded to
+  the 'docker-run' command.
+
+  (!) Syntax must be: '--my-option=my-value' - equal signs are required
+      for any option that take an argument.
+
+  Examples:
+    docker-here --privileged alpine ls
+    docker-here --volume=/tmp:/mount-point alpine ls /mount-point
+    docker-here --pull=never my-local-image ls
 
 POSITIONAL ARGUMENTS
   IMAGE   The container image to run.
@@ -124,6 +124,7 @@ EXAMPLES
     docker-here alpine --src ~/Downloads -- ls -l .
     docker-here alpine --dest /foo -- ls -l /foo
     docker-here alpine:latest@sha256:d34db33f[...] -- ls -l /foo
+    docker-here --volume=/tmp:/mount-point alpline ls -l /mount-point
 ```
 
 [download]: https://raw.githubusercontent.com/NyanKiyoshi/docker-here/refs/heads/main/docker-here

--- a/docker-here
+++ b/docker-here
@@ -6,7 +6,7 @@ usage() {
     name=$(basename "$0")
 
     # Note: convention used is max line length of 80 chars.
-    echo $"Usage: $name [OPTIONS...] [--] IMAGE [ARGS...]
+    echo $"Usage: $name [OPTIONS...] [DOCKER_OPTIONS...] [--] IMAGE [ARGS...]
 
 $name - Runs a given container image in a given directory (defaults to current
 directory)
@@ -24,19 +24,19 @@ OPTIONS
 
                           Default: \$PWD
 
-  --privileged            Run the container as privileged (passes
-                          '--privileged' to 'docker run')
-
-  --entrypoint COMMAND  The entrypoint to pass to 'docker run'.
-
-  --pull       POLICY   The pull policy to pass to 'docker run'.
-                        Options: always, missing, never, newer
-                                 (default: 'missing')
-
-                        Note: the actual options may vary between docker
-                              backends (e.g., docker vs podman).
-
   --                    Indicates the end of the options for $name.
+
+DOCKER OPTIONS
+  Any options that unrecognized by 'docker-here' will be forwarded to
+  the 'docker-run' command.
+
+  (!) Syntax must be: '--my-option=my-value' - equal signs are required
+      for any option that take an argument.
+
+  Examples:
+    $name --privileged alpine ls
+    $name --volume=/tmp:/mount-point alpine ls /mount-point
+    $name --pull=never my-local-image ls
 
 POSITIONAL ARGUMENTS
   IMAGE   The container image to run.
@@ -53,7 +53,8 @@ EXAMPLES
     $name alpine sh -uxc 'ls -l \"\$PWD\" ; cat /etc/os-release'
     $name alpine --src ~/Downloads -- ls -l .
     $name alpine --dest /foo -- ls -l /foo
-    $name alpine:latest@sha256:d34db33f[...] -- ls -l /foo"
+    $name alpine:latest@sha256:d34db33f[...] -- ls -l /foo
+    $name --volume=/tmp:/mount-point alpline ls -l /mount-point"
 }
 
 
@@ -103,20 +104,6 @@ while [[ $# -gt 0 ]]; do
             dest_path="$2"
             shift 2
             ;;
-        --privileged)
-            docker_run_args+=("--privileged")
-            shift
-            ;;
-        --pull)
-            peek_next "$@"
-            docker_run_args+=("--pull=$2")
-            shift 2
-            ;;
-        --entrypoint)
-            peek_next "$@"
-            docker_run_args+=("--entrypoint=$2")
-            shift 2
-            ;;
         -h | --help)
             usage
             exit 0
@@ -142,10 +129,8 @@ while [[ $# -gt 0 ]]; do
             break
             ;;
         --*)
-            # If we reach here, then we didn't find any matching option.
-            echo "Unknown option: $1" >&2
-            usage >&2
-            exit 1
+            docker_run_args+=("$1")
+            shift
             ;;
         *)
             image="$1"

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -94,17 +94,14 @@ def test_mount_paths(src: str | None, dest: str | None, expected_pwd: Path | Pos
         #   --src shouldn't be parsed by docker-here
         ([DEFAULT_IMAGE, "echo", "--src"], "--src", True),  # OK
         # Given,
-        #   - --non-existent is provided before the image name
+        #   - An unrecognized argument (--volume) is provided
         # Then,
-        #   docker-here should parse --non-existent and complain the options
-        #   is unknown.
-        (["--non-existent", DEFAULT_IMAGE, "echo"], "", False),  # Not OK
-        # Given,
-        #   - --non-existent is provided before '--'
-        # Then,
-        #   docker-here should parse --non-existent and complain the options
-        #   is unknown.
-        (["--non-existent", "--", DEFAULT_IMAGE, "echo"], "", False),  # Not OK
+        #   --volume should be forwarded to 'docker run'
+        (
+            ["--volume=.:/mounted", DEFAULT_IMAGE, "sh", "-c", "cd /mounted && pwd"],
+            "/mounted",
+            True,
+        ),  # OK
     ],
 )
 def test_stops_parsing_arguments(args: list[str], expected_stdout: str, is_ok: bool):


### PR DESCRIPTION
This adds the possibility to pass arbitary options to 'docker run', such as:

```
$ docker-here --volume=/foo:/bar --pull=never [...]
```

This should remove most limitations caused by wrapping 'docker run'.

Note: this is a breaking change, if you are currently using `docker-here`
with the option `--entrypoint` or `--pull`, then you need to change them like so:

- Before this change (≤ v1.1.0):
  ```
  $ docker-here --entrypoint my-command
  $ docker-here --pull never
  ```
- After this change, do this instead (notice the added `=`):
  ```
  $ docker-here --entrypoint=my-command
  $ docker-here --pull=never
  ```